### PR TITLE
Bugfix for challenge creation and make attack work

### DIFF
--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -49,23 +49,24 @@ class ChallengesController < ApplicationController
     @monster = Monster.find(@challenge.monster_id)
 
     @damage_dealt = calculate_damage
-    @monster.healthpoints -= @damage_dealt
-    redirect_to challenge_path(@challenge)
+    @monster.update(hitpoints: (@monster.hitpoints - @damage_dealt))
+    redirect_to treasure_chest_challenge_path(@challenge.treasure_chest, @challenge)
+    raise
   end
 
   private
 
   def check_attack
-    attack_chance = 0
     if @monster_rage > 75
       attack_chance = 80
     elsif @monster_rage > 50
       attack_chance = 40
+    else
+      attack_chance = 20
     end
-    
     return unless rand(1..100) <= attack_chance
 
-    @player.update(healthpoints: (@player.healthpoints - 10))
+    @player.update(healthpoints: (@player.healthpoints - @monster.hitpoints))
   end
 
   def challenge_params
@@ -84,9 +85,9 @@ class ChallengesController < ApplicationController
     if rand(1..10) == 1
       0
     elsif rand(1..10) == 2
-      @player.hitpoints * rand(1.4..2.0).to_i
+      (@player.hitpoints * rand(1.4..2.0)) / 10
     else
-      @player.hitpoints
+      @player.hitpoints / 10
     end
   end
 

--- a/app/models/monster.rb
+++ b/app/models/monster.rb
@@ -1,5 +1,4 @@
 class Monster < ApplicationRecord
-  belongs_to :challenge
   has_one_attached :picture
 
   def icon_creator

--- a/app/views/challenges/show.html.erb
+++ b/app/views/challenges/show.html.erb
@@ -24,4 +24,5 @@
     <p style="color: #41C835">Your healthpoints: <%= @player.healthpoints.to_i %></p>
   </div>
   <%= link_to "Enrage the monster", new_treasure_chest_challenge_expense_path(@challenge.treasure_chest, @challenge) %>
+  <%= link_to "Attack!", treasure_chest_challenge_attack_path(@challenge.treasure_chest, @challenge) %>
 </div>


### PR DESCRIPTION
I fixed a bug with challenge creation (circular validation) and added a working attack button. It now targets the monster's hitpoints (making it less effective when it attacks). We can't really target monster healtpoints as far as I see without undermining the challenge goal, which is saving money. If you have any suggestions on that, let me know :) 